### PR TITLE
Schneider freightpower load parser with 2fa

### DIFF
--- a/src/auth/schneider_auth.py
+++ b/src/auth/schneider_auth.py
@@ -521,8 +521,7 @@ class SchneiderAuth:
                                 continue
                         
                         if code_field:
-                            # Очистка поля и ввод кода
-                            await code_field.clear()
+                            # Ввод кода (fill автоматически очищает поле)
                             await code_field.fill(code)
                             logger.info(f"✅ Код введен: {code}")
                             


### PR DESCRIPTION
Fix 2FA input by removing an invalid `clear()` call on an `ElementHandle`, as `fill()` handles clearing automatically.

The previous code attempted to call `clear()` on a Playwright `ElementHandle` object, which does not possess this method, leading to an `AttributeError`. The `fill()` method inherently clears the input field before typing, making the explicit `clear()` call unnecessary and erroneous.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc9f27a0-efba-4d4b-bc98-e8debcf1f5ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dc9f27a0-efba-4d4b-bc98-e8debcf1f5ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

